### PR TITLE
non-tuple slicing is deprecated.

### DIFF
--- a/batchgenerators/augmentations/crop_and_pad_augmentations.py
+++ b/batchgenerators/augmentations/crop_and_pad_augmentations.py
@@ -123,11 +123,11 @@ def crop(data, seg=None, crop_size=128, margins=(0, 0, 0), crop_type="center",
         lbs = [max(0, lbs[d]) for d in range(dim)]
 
         slicer_data = [slice(0, data_shape_here[1])] + [slice(lbs[d], ubs[d]) for d in range(dim)]
-        data_cropped = data[b][slicer_data]
+        data_cropped = data[b][tuple(slicer_data)]
 
         if seg_return is not None:
             slicer_seg = [slice(0, seg_shape_here[1])] + [slice(lbs[d], ubs[d]) for d in range(dim)]
-            seg_cropped = seg[b][slicer_seg]
+            seg_cropped = seg[b][tuple(slicer_seg)]
 
         if any([i > 0 for j in need_to_pad for i in j]):
             data_return[b] = np.pad(data_cropped, need_to_pad, pad_mode, **pad_kwargs)


### PR DESCRIPTION
Numpy warning

```
/root/batchgenerators/batchgenerators/augmentations/crop_and_pad_augmentations.py:126: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `a
rr[np.array(seq)]`, which will result either in an error or a different result.
  data_cropped = data[b][slicer_data]
```