### PR TITLE
Make transforms=None pass in STA

### DIFF
--- a/batchgenerators/dataloading/single_threaded_augmenter.py
+++ b/batchgenerators/dataloading/single_threaded_augmenter.py
@@ -43,5 +43,6 @@ class SingleThreadedAugmenter(object):
 
     def __next__(self):
         item = next(self.data_loader)
-        item = self.transform(**item)
+        if self.transform is not None:
+            item = self.transform(**item)
         return item


### PR DESCRIPTION
Multithreaded augmenter accepts `transforms` to be `None` (for applying no transform at all), but singlethreaded augmenter fails on it.

This one-liner should fix this and make the behavior same for both augmenters.

cc @FabianIsensee 