### PR TITLE
Fix missing tuple unpacking in CenterCropSegTransform

### DIFF
--- a/batchgenerators/transforms/crop_and_pad_transforms.py
+++ b/batchgenerators/transforms/crop_and_pad_transforms.py
@@ -60,7 +60,7 @@ class CenterCropSegTransform(AbstractTransform):
         seg = data_dict.get(self.label_key)
 
         if seg is not None:
-            data_dict[self.label_key] = center_crop(seg, self.output_size, None)
+            data_dict[self.label_key] = center_crop(seg, self.output_size, None)[0]
         else:
             from warnings import warn
             warn("You shall not pass data_dict without seg: Used CenterCropSegTransform, but there is no seg", Warning)


### PR DESCRIPTION
Hi,
You missed three chars. Alternatively you could unpack it before the equal sign or change the crop function to remove only data instead of a tuple.

Thanks for the good work!