### PR TITLE
Use pillow 7.1.2+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pillow<7.1
+pillow>=7.1.2
 threadpoolctl
 scikit-learn
 numpy>=1.10.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='batchgenerators',
       license='Apache License Version 2.0, January 2004',
       packages=find_packages(exclude=["tests"]),
       install_requires=[
-            "pillow<7.1",
+            "pillow>=7.1.2",
             "numpy>=1.10.2",
             "scipy",
             "scikit-image",


### PR DESCRIPTION
The Pillow<7.1 requirement/restriction was encountered in testing https://github.com/NixOS/nixpkgs/pull/77714 (see [this](https://github.com/NixOS/nixpkgs/pull/77714#issuecomment-631460339) comment)

___

Pillow was restricted to <7.1 in https://github.com/MIC-DKFZ/batchgenerators/commit/67f7503dbe054226cd15aa0d933b9e5c8d9c5b9a.

I tested against 7.1.0, 7.1.1, and 7.1.2, and encountered test failures for both 7.1.0 and 7.1.1. 
7.1.2 seemed to encounter no failures and built successfully using nixpkgs.

<details>
<summary>Pillow 7.1.0 log</summary>

```
builder for '/nix/store/8hi7mrqlr5ax2z60m8h7qjmwdsiy4yyp-python3.7-imageio-2.6.1.drv' failed with exit code 1; last 10 log lines:
  =============================== warnings summary ===============================
  tests/test_ffmpeg.py::test_reader_more
  tests/test_ffmpeg.py::test_webcam
  tests/test_ffmpeg.py::test_webcam_get_next_data
  tests/test_ffmpeg.py::test_webcam_process_termination
    /nix/store/r3b6627xcvl5gpf5x57971kjjkd4a3ym-python3.7-imageio-ffmpeg-0.3.0/lib/python3.7/site-packages/imageio_ffmpeg/_parsing.py:46: PendingDeprecationWarning: isAlive() is deprecated, use is_alive() instead
      while self.isAlive() and time.time() < etime:  # pragma: no cover
  
  -- Docs: https://docs.pytest.org/en/latest/warnings.html
  == 7 failed, 70 passed, 61 skipped, 3 xfailed, 4 warnings in 67.66s (0:01:07) ==
cannot build derivation '/nix/store/yqiqamfg56fqhb7n64hiwfjzrdw5g1ii-python3.7-scikit-image-0.16.2.drv': 1 dependencies couldn't be built
cannot build derivation '/nix/store/dxxgiqj2mjslcikbb53vc8sycn358b95-python3.7-batchgenerators-0.20.0.drv': 1 dependencies couldn't be built
[2 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/dxxgiqj2mjslcikbb53vc8sycn358b95-python3.7-batchgenerators-0.20.0.drv' failed
```

</details>

<details>
<summary>Pillow 7.1.1 log</summary>

```
/nix/store/xirkdz374pbx0pf8521349m5ylkhpkg1-python3.7-future-0.18.2/lib/python3.7/site-packages/future/standard_library/__init__.py:65
/nix/store/xirkdz374pbx0pf8521349m5ylkhpkg1-python3.7-future-0.18.2/lib/python3.7/site-packages/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
      import imp
  
/nix/store/jpq60whbk9hc2ipvyhm2i92prws21jdr-python3.7-unittest2-1.1.0/lib/python3.7/site-packages/unittest2/compatibility.py:143
/nix/store/jpq60whbk9hc2ipvyhm2i92prws21jdr-python3.7-unittest2-1.1.0/lib/python3.7/site-packages/unittest2/compatibility.py:143: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
      class ChainMap(collections.MutableMapping):
  
  -- Docs: https://docs.pytest.org/en/latest/warnings.html
  ================== 10 failed, 59 passed, 2 warnings in 29.26s ==================
[6 built (1 failed), 0.0 MiB DL]
error: build of '/nix/store/z2xkrrkh2facmrhk1zwzpzflbw1rnwra-python3.7-batchgenerators-0.20.0.drv' failed

```
</details>

___

Hopefully this is enough to update this requirement, though I am unsure if there is anything outside of the tests that is broken due to Pillow 7.1.0.