### PR TITLE
Developing ta wald

### DIFF
--- a/batchgenerators/utilities/custom_types.py
+++ b/batchgenerators/utilities/custom_types.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Tuple, Any, Protocol
+from typing import Union, Tuple, Any
+from typing_extensions import Protocol
 import numpy as np
 
 class SomeCallable(Protocol):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ scipy
 scikit-image
 scikit-learn
 unittest2
+mypy


### PR DESCRIPTION
Added downwards compatability of batchgenerators.
Current ScalarType Callable[[Any, ...] breaks as <=Python 3.8 expects Argtypes in the List only (no ellipsis).
Workaround by defining Protocol which has the wanted signature and using that.