### PR TITLE
Typehinting backward compatibility fix

### DIFF
--- a/batchgenerators/utilities/custom_types.py
+++ b/batchgenerators/utilities/custom_types.py
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union, Tuple, Any
-from typing_extensions import Protocol
+from typing import Union, Tuple, Any, Callable
 import numpy as np
 
-class SomeCallable(Protocol):
-    def __call__(self, a: Any, *args, **kwargs) -> Union[float, int]: ...
 
-ScalarType = Union[Union[int, float], Tuple[float, float], SomeCallable]
+ScalarType = Union[Union[int, float], Tuple[float, float], Callable[..., Union[int, float]]]
 
 
 def sample_scalar(scalar_type: ScalarType, *args):

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ scipy
 scikit-image
 scikit-learn
 unittest2
-mypy


### PR DESCRIPTION
Fixed backward compatibility of type hinting as no arguments can also be passed to function.