### PR TITLE
(Typo) remove double scikit-learn

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 pillow>=7.1.2
 threadpoolctl
-scikit-learn
 numpy>=1.10.2
 scipy
 scikit-image


### PR DESCRIPTION
The package scikit-learn was listed twice in requirements.txt