### PR TITLE
fix: non-ascii support

### DIFF
--- a/batchgenerators/utilities/file_and_folder_operations.py
+++ b/batchgenerators/utilities/file_and_folder_operations.py
@@ -72,7 +72,7 @@ def load_json(file: str):
 
 def save_json(obj, file: str, indent: int = 4, sort_keys: bool = True) -> None:
     with open(file, 'w') as f:
-        json.dump(obj, f, sort_keys=sort_keys, indent=indent)
+        json.dump(obj, f, sort_keys=sort_keys, indent=indent，ensure_ascii=False)
 
 
 def pardir(path: str):


### PR DESCRIPTION
Sometimes people need non-ascii support, like description in dataset.json which used in nnUNet.