### PR TITLE
Stop using deprecated scipy.ndimage namespaces

### DIFF
--- a/batchgenerators/augmentations/utils.py
+++ b/batchgenerators/augmentations/utils.py
@@ -16,11 +16,14 @@
 import random
 import numpy as np
 from copy import deepcopy
-from scipy.ndimage import map_coordinates, fourier_gaussian
-from scipy.ndimage.filters import gaussian_filter, gaussian_gradient_magnitude
-from scipy.ndimage.morphology import grey_dilation
+from scipy.ndimage import (
+    gaussian_filter,
+    gaussian_gradient_magnitude,
+    grey_dilation,
+    fourier_gaussian,
+    label as lb,
+    map_coordinates)
 from skimage.transform import resize
-from scipy.ndimage.measurements import label as lb
 
 
 def generate_elastic_transform_coordinates(shape, alpha, sigma):


### PR DESCRIPTION
With recent versions of scipy, a lot of warnings are raised:

>DeprecationWarning: Please use `label` from the `scipy.ndimage` namespace, the `scipy.ndimage.measurements` namespace is deprecated.

>DeprecationWarning: Please use `grey_dilation` from the `scipy.ndimage` namespace, the `scipy.ndimage.morphology` namespace is deprecated.
    from scipy.ndimage.morphology import grey_dilation

>Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.

This PR removes them