### PR TITLE
Remove lambda usage in BlankRectangleTransform

### DIFF
--- a/batchgenerators/transforms/noise_transforms.py
+++ b/batchgenerators/transforms/noise_transforms.py
@@ -133,6 +133,19 @@ class BlankSquareNoiseTransform(AbstractTransform):
                                                                          self.channel_wise_n_val, self.square_pos)
         return data_dict
 
+class ColorFunctionExtractor:
+    def __init__(self, rectangle_value):
+        self.rectangle_value = rectangle_value
+
+    def __call__(self, x):
+        if np.isscalar(self.rectangle_value):
+            return self.rectangle_value
+        elif callable(self.rectangle_value):
+            return self.rectangle_value(x)
+        elif isinstance(self.rectangle_value, (tuple, list)):
+            return np.random.uniform(*self.rectangle_value)
+        else:
+            raise RuntimeError("unrecognized format for rectangle_value")
 
 class BlankRectangleTransform(AbstractTransform):
     def __init__(self, rectangle_size, rectangle_value, num_rectangles, force_square=False, p_per_sample=0.5,
@@ -181,14 +194,8 @@ class BlankRectangleTransform(AbstractTransform):
         self.apply_to_keys = apply_to_keys
 
         # intensity value
-        if np.isscalar(rectangle_value):
-            self.color_fn = lambda x: rectangle_value
-        elif callable(rectangle_value):
-            self.color_fn = lambda x: rectangle_value(x)
-        elif isinstance(rectangle_value, (tuple, list)):
-            self.color_fn = lambda x: np.random.uniform(*rectangle_value)
-        else:
-            raise RuntimeError("unrecognized format for rectangle_value")
+        self.color_fn = ColorFunctionExtractor(rectangle_value)
+
 
     def __call__(self, **data_dict):
         for k in self.apply_to_keys:


### PR DESCRIPTION
Lambda isn't pickable so the usage of lambda here affected multi-gpus training. 
This particular function is used by nnUNetTrainerDA5 