### PR TITLE
move unittest2 to extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,13 @@ setup(name='batchgenerators',
             "scikit-image",
             "scikit-learn",
             "future",
-            "unittest2",
             "threadpoolctl"
       ],
+      extras_require={
+            "dev": [
+                "unittest2"
+            ]
+      },
       keywords=['data augmentation', 'deep learning', 'image segmentation', 'image classification',
                 'medical image analysis', 'medical image segmentation'],
       )


### PR DESCRIPTION
This PR moves the dependency on unittest2 to the `extras_require` so that users of the library do not have to install unittest2.

To test, run:
```
python -m venv .venv
source .venv/bin/activate
pip install .
pip freeze | grep unittest2
```
and it should return nothing

Then again with:
```
pip install ".[dev]"
pip freeze | grep unittest2
```
Should return unittest2 and its version
