### PR TITLE
10x performance improvement of DownsampleSegForDSTransform2 in nnunet by moving 1 line of code

### DIFF
--- a/batchgenerators/augmentations/utils.py
+++ b/batchgenerators/augmentations/utils.py
@@ -591,11 +591,12 @@ def resize_segmentation(segmentation, new_shape, order=3):
     :return:
     '''
     tpe = segmentation.dtype
-    unique_labels = np.unique(segmentation)
+    
     assert len(segmentation.shape) == len(new_shape), "new shape must have same dimensionality as segmentation"
     if order == 0:
         return resize(segmentation.astype(float), new_shape, order, mode="edge", clip=True, anti_aliasing=False).astype(tpe)
     else:
+        unique_labels = np.unique(segmentation)
         reshaped = np.zeros(new_shape, dtype=segmentation.dtype)
 
         for i, c in enumerate(unique_labels):


### PR DESCRIPTION
Hi,

Finding unique labels is not necessary when order == 0. In DownsampleSegForDSTransform2 in nnunet, this function is called multiple times, and it all adds up, especially in the limited CPU scenario with high-res images. By introducing this change, I've reduced the time of this transform from ~2 seconds to ~0.2 seconds.

Best,