### PR TITLE
Fix deprecated scipy.ndimage import paths

### DIFF
--- a/batchgenerators/augmentations/utils.py
+++ b/batchgenerators/augmentations/utils.py
@@ -16,11 +16,10 @@
 import random
 import numpy as np
 from copy import deepcopy
-from scipy.ndimage import map_coordinates, fourier_gaussian
-from scipy.ndimage.filters import gaussian_filter, gaussian_gradient_magnitude
-from scipy.ndimage.morphology import grey_dilation
+from scipy.ndimage import (map_coordinates, fourier_gaussian, gaussian_filter,
+                           gaussian_gradient_magnitude, grey_dilation)
+from scipy.ndimage import label as lb
 from skimage.transform import resize
-from scipy.ndimage.measurements import label as lb
 import pandas as pd
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pillow>=7.1.2
 threadpoolctl
 scikit-learn
 numpy>=1.10.2
-scipy
+scipy>=1.0.0
 scikit-image
 scikit-learn
 unittest2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='batchgenerators',
       install_requires=[
             "pillow>=7.1.2",
             "numpy>=1.10.2",
-            "scipy",
+            "scipy>=1.0.0",
             "scikit-image",
             "scikit-learn",
             "future",


### PR DESCRIPTION
I am getting some warning like
```
../usr/local/lib/python3.10/dist-packages/batchgenerators/augmentations/utils.py:23
  /usr/local/lib/python3.10/dist-packages/batchgenerators/augmentations/utils.py:23: DeprecationWarning: Please use `label` from the `scipy.ndimage` namespace, the `scipy.ndimage.measurements` namespace is deprecated.
    from scipy.ndimage.measurements import label as lb
```
this should fix that