### PR TITLE
remove dependencies unittest2 and future

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ celerybeat-schedule
 # virtualenv
 venv/
 ENV/
+.venv/
 
 # Spyder project settings
 .spyderproject

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "batchgenerators"
+version = "0.25.2"
+description = "Data augmentation toolkit"
+readme = "README.md"
+authors = [
+    {name = "Division of Medical Image Computing, German Cancer Research Center AND Applied Computer Vision Lab, Helmholtz Imaging Platform", email = "f.isensee@dkfz-heidelberg.de"}
+]
+license = {text = "Apache License Version 2.0, January 2004"}
+keywords = [
+    "data augmentation", "deep learning", "image segmentation", 
+    "image classification", "medical image analysis", 
+    "medical image segmentation"
+]
+dependencies = [
+    "numpy>=1.10.2",
+    "pandas",
+    "pillow>=7.1.2",
+    "scikit-image",
+    "scikit-learn",
+    "scipy",
+    "threadpoolctl"
+]
+
+[project.urls]
+homepage = "https://github.com/MIC-DKFZ/batchgenerators"
+
+[tool.setuptools.packages.find]
+exclude = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-pillow>=7.1.2
-threadpoolctl
-scikit-learn
 numpy>=1.10.2
-scipy
+pillow>=7.1.2
 scikit-image
 scikit-learn
-unittest2
+scikit-learn
+scipy
+threadpoolctl

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,3 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(name='batchgenerators',
-      version='0.25.1',
-      description='Data augmentation toolkit',
-      url='https://github.com/MIC-DKFZ/batchgenerators',
-      author='Division of Medical Image Computing, German Cancer Research Center AND Applied Computer Vision Lab, '
-             'Helmholtz Imaging Platform',
-      author_email='f.isensee@dkfz-heidelberg.de',
-      license='Apache License Version 2.0, January 2004',
-      packages=find_packages(exclude=["tests"]),
-      install_requires=[
-            "pillow>=7.1.2",
-            "numpy>=1.10.2",
-            "scipy",
-            "scikit-image",
-            "scikit-learn",
-            "future",
-            "pandas",
-            "unittest2",
-            "threadpoolctl"
-      ],
-      keywords=['data augmentation', 'deep learning', 'image segmentation', 'image classification',
-                'medical image analysis', 'medical image segmentation'],
-      )
+setup()

--- a/tests/test_axis_mirroring.py
+++ b/tests/test_axis_mirroring.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import unittest
-import unittest2
+import unittest
 import numpy as np
 from batchgenerators.dataloading.single_threaded_augmenter import SingleThreadedAugmenter
 from skimage import data
@@ -23,7 +23,7 @@ from tests.DataGenerators import BasicDataLoader
 from batchgenerators.transforms.spatial_transforms import MirrorTransform
 
 
-class TestMirrorAxis(unittest2.TestCase):
+class TestMirrorAxis(unittest.TestCase):
     def setUp(self):
         self.seed = 1234
 


### PR DESCRIPTION
Fixes #77. 

Remove dependency to unittest2 and future. 
- future isn't used anywhere in the code
- unittest2 is used only in one test

I also slightly modernized the package. All configuration settings are now in a `pyproject.toml`.

I ran the tests locally and they pass:

![image](https://github.com/user-attachments/assets/9b636d63-1cf5-423a-8bb3-00788f00c384)
