### PR TITLE
Drop unittest2 from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(name='batchgenerators',
             "scikit-learn",
             "future",
             "pandas",
-            "unittest2",
             "threadpoolctl"
       ],
       keywords=['data augmentation', 'deep learning', 'image segmentation', 'image classification',


### PR DESCRIPTION
As version 0.19.5 dropped Python 2 support the unittest2 package is no longer required. It provides backwards compatibility for the unittest module from the Python 3 standard library for Python 2.