### PR TITLE
Fix for "One or more background workers are no longer alive. Exiting" errors

### DIFF
--- a/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py
+++ b/batchgenerators/dataloading/nondet_multi_threaded_augmenter.py
@@ -34,11 +34,14 @@ try:
 except ImportError:
     torch = None
 
+from threading import Lock
+global_mutex = Lock()
 
 def producer(queue: Queue, data_loader, transform, thread_id: int, seed,
              abort_event: Event, wait_time: float = 0.02):
     # the producer will set the abort event if something happens
-    with threadpool_limits(1, None):
+    # with threadpool_limits(1, None):
+        global_mutex.acquire() # using instead of threadpool_limits for thread safety
         np.random.seed(seed)
         data_loader.set_thread_id(thread_id)
         item = None
@@ -72,7 +75,9 @@ def producer(queue: Queue, data_loader, transform, thread_id: int, seed,
             traceback.print_exc()
             abort_event.set()
             return
-
+            
+        #End of mutex section    
+        global_mutex.release()
 
 def pin_memory_of_all_eligible_items_in_dict(result_dict):
     for k in result_dict.keys():


### PR DESCRIPTION
See also https://github.com/MIC-DKFZ/nnUNet/pull/2910, this is the same issue and fix.
Hello,

We encountered the "One or more background workers are no longer alive. Exiting" error as described in:

https://github.com/MIC-DKFZ/batchgenerators/issues/134
https://github.com/MIC-DKFZ/batchgenerators/issues/133

when running nnUNet on an HPC cluster. A colleague and I looked into this issue and came across this link:
https://github.com/joblib/threadpoolctl/issues/176

which says that using with threadpool_limits is not thread safe and to use a global mutex instead. with threadpool_limits is used in both nnUNet and batchgenerators libraries. By using a global mutex instead of with threadpool limits as done in this pull request, we no longer encounter this issue. We verified that nnUNet output is similar (they can't be identical with the non-determinative multi-threaded launcher).

We encountered this error with both nnUNet and the batchgenerators library so a similar pull request was made in nnUNet.