### PR TITLE
[FIX] deterministic augmentations in MTA by setting seed of all used RNGs in the MTA multiprocessing environment

### DIFF
--- a/batchgenerators/dataloading/multi_threaded_augmenter.py
+++ b/batchgenerators/dataloading/multi_threaded_augmenter.py
@@ -24,6 +24,7 @@ import logging
 from multiprocessing import Event
 from time import sleep, time
 from threadpoolctl import threadpool_limits
+import random
 
 try:
     import torch
@@ -34,6 +35,8 @@ except ImportError:
 def producer(queue, data_loader, transform, thread_id, seed, abort_event,
              pause_event=None, wait_time: float = 0.02):
     np.random.seed(seed)
+    random.seed(seed) if seed is not None else None
+    torch.manual_seed(seed) if seed is not None else None
     data_loader.set_thread_id(thread_id)
     item = None
 


### PR DESCRIPTION
Hey! Thanks for this amazing repo.

This PR to make augmentations deterministic in `MultiThreadedAugmenter` (MTA) by setting the seed of all used RNGs in `batchgenerators` (numpy, torch and random) inside the MTA multiprocessing environment. This is in line with previous PRs, that attempt to make augmentations deterministic in `batchgenerators` and `batchgeneratorsv2` by using a single numpy RNG for all augmentations (cf. https://github.com/MIC-DKFZ/batchgeneratorsv2/pull/13). 
However, as stated by @FabianIsensee in the corresponding PR:
> This [PR](https://github.com/MIC-DKFZ/batchgeneratorsv2/pull/13) is based on the assumption that the torch RNG is not properly seeded in a multiprocessing environment. Why is it not possible to just seed all used RNGs to obtain deterministic augmentations. I would like to avoid bouncing back and forth between torch and numpy all the time. The few times that we are doing this already bug be quite a lot.

The current PR actually adresses this, ensuring batches are returned both in the same order and with the same augmentations. Nevertheless, I believe the 'clean' way would be indeed to use a single RNG convention, but setting the seed of all used RNGs at least ensure augmentations are similar across runs when using a MTA.